### PR TITLE
chore: clean pair generation step

### DIFF
--- a/src/software/SfM/main_PairGenerator.cpp
+++ b/src/software/SfM/main_PairGenerator.cpp
@@ -14,16 +14,6 @@
 
 #include <iostream>
 
-/**
- * @brief Current list of available pair mode
- *
- */
-enum EPairMode
-{
-  PAIR_EXHAUSTIVE = 0, // Build every combination of image pairs
-  PAIR_CONTIGUOUS = 1  // Only consecutive image pairs (useful for video mode)
-};
-
 using namespace openMVG;
 using namespace openMVG::sfm;
 
@@ -32,14 +22,6 @@ void usage( const char* argv0 )
   std::cerr << "Usage: " << argv0 << '\n'
             << "[-i|--input_file]         A SfM_Data file\n"
             << "[-o|--output_file]        Output file where pairs are stored\n"
-            << "\n[Optional]\n"
-            << "[-m|--pair_mode] mode     Pair generation mode\n"
-            << "       EXHAUSTIVE:        Build all possible pairs. [default]\n"
-            << "       CONTIGUOUS:        Build pairs for contiguous images (use it with --contiguous_count parameter)\n"
-            << "[-c|--contiguous_count] X Number of contiguous links\n"
-            << "       X: will match 0 with (1->X), ...]\n"
-            << "       2: will match 0 with (1,2), 1 with (2,3), ...\n"
-            << "       3: will match 0 with (1,2,3), 1 with (2,3,4), ...\n"
             << std::endl;
 }
 
@@ -50,15 +32,10 @@ int main( int argc, char** argv )
 
   std::string sSfMDataFilename;
   std::string sOutputPairsFilename;
-  std::string sPairMode        = "EXHAUSTIVE";
-  int         iContiguousCount = -1;
 
   // Mandatory elements:
   cmd.add( make_option( 'i', sSfMDataFilename, "input_file" ) );
   cmd.add( make_option( 'o', sOutputPairsFilename, "output_file" ) );
-  // Optional elements:
-  cmd.add( make_option( 'm', sPairMode, "pair_mode" ) );
-  cmd.add( make_option( 'c', iContiguousCount, "contiguous_count" ) );
 
   try
   {
@@ -79,9 +56,6 @@ int main( int argc, char** argv )
             << argv[ 0 ] << "\n"
             << "--input_file       : " << sSfMDataFilename << "\n"
             << "--output_file      : " << sOutputPairsFilename << "\n"
-            << "Optional parameters\n"
-            << "--pair_mode        : " << sPairMode << "\n"
-            << "--contiguous_count : " << iContiguousCount << "\n"
             << std::endl;
 
   if ( sSfMDataFilename.empty() )
@@ -95,23 +69,6 @@ int main( int argc, char** argv )
     usage( argv[ 0 ] );
     std::cerr << "[Error] Output file not set." << std::endl;
     exit( EXIT_FAILURE );
-  }
-
-  EPairMode pairMode;
-  if ( sPairMode == "EXHAUSTIVE" )
-  {
-    pairMode = PAIR_EXHAUSTIVE;
-  }
-  else if ( sPairMode == "CONTIGUOUS" )
-  {
-    if ( iContiguousCount == -1 )
-    {
-      usage( argv[ 0 ] );
-      std::cerr << "[Error] Contiguous pair mode selected but contiguous_count not set." << std::endl;
-      exit( EXIT_FAILURE );
-    }
-
-    pairMode = PAIR_CONTIGUOUS;
   }
 
   // 1. Load SfM data scene
@@ -128,24 +85,9 @@ int main( int argc, char** argv )
   // 2. Compute pairs
   std::cout << "Computing pairs." << std::endl;
   Pair_Set pairs;
-  switch ( pairMode )
-  {
-    case PAIR_EXHAUSTIVE:
-    {
-      pairs = exhaustivePairs( NImage );
-      break;
-    }
-    case PAIR_CONTIGUOUS:
-    {
-      pairs = contiguousWithOverlap( NImage, iContiguousCount );
-      break;
-    }
-    default:
-    {
-      std::cerr << "Unknown pair mode" << std::endl;
-      exit( EXIT_FAILURE );
-    }
-  }
+  const int overlapCount = 2;
+
+  pairs = contiguousWithOverlap( NImage, overlapCount );
 
   // 3. Save pairs
   std::cout << "Saving pairs." << std::endl;


### PR DESCRIPTION
- Cleans pair generation step by removing `EXHAUSTIVE` mode. It is rather slow for real-time performance, and the point cloud quality decrease is unnoticeable. 
- Windows size is 2 by default now. We can adjust it easily later but seems quite fine. 

**Note:** There is `inline Pair_Set exhaustivePairs(const size_t N)` in `Pair_Builder.hpp`. It is used in the matching step. Do not forget to remove this once that step is also cleaned. 